### PR TITLE
Squash SPLICE_F_GIFT warning

### DIFF
--- a/skcipher/test.c
+++ b/skcipher/test.c
@@ -30,7 +30,7 @@
 #include <sys/uio.h>
 #define SOL_ALG 279
 
-#define SPLICE_F_GIFT    (0x08)    /* pages passed in are a gift */
+#define SPLICE_F_GIFT    8    /* pages passed in are a gift */
 struct sockaddr_alg {
     __u16    salg_family;
     __u8    salg_type[14];


### PR DESCRIPTION
0x08 causes the following warning. Verified header and define value on both i686 and x86_64.

test.c:33:0: warning: "SPLICE_F_GIFT" redefined
 #define SPLICE_F_GIFT    (0x08)   /\* pages passed in are a gift */
...
